### PR TITLE
Initial commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,36 @@
-# Compiled class file
-*.class
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
 
-# Log file
-*.log
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
 
-# BlueJ files
-*.ctxt
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
 
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
+### VS Code ###
+.vscode/
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
+## secrets
+repo_info.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:8-jdk-alpine
+MAINTAINER aviorn36@gmail.com
+WORKDIR /gitsync/app/data/
+COPY /target/GitSync-0.0.1-SNAPSHOT.jar app.jar
+CMD java -jar app.jar

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ How to sync any repo in gitLab with this module.
 
 Locally : Pass in environment variables (as mentioned below) and run locally.
 
-DockerImage : Build docker image and run with environment variables (as mentioned below).
+DockerImage : Build docker image and run with environment variables (as mentioned below).\
+
+(or use this to pull image : docker pull aviorn36/gitsyncmodule)
 
 Docker command :
 docker run -d \ 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # GitLabJ-module
 This modules can be integrated with your application to provide runtime-synchronization of config-files
+
+Functionality:
+1. Initialization - this module connects and downloads/save files&folders from GitLab to application server with environment configurations specified.
+2. Runtime - /reloadDynamicFlowConfigurationV2, can be used to dynamically change the downloaded files&folder of every commit.
+
+How to sync any repo in gitLab with this module.
+
+Locally : Pass in environment variables (as mentioned below) and run locally.
+
+DockerImage : Build docker image and run with environment variables (as mentioned below).
+
+Docker command :
+docker run -d \ 
+--name container_name \
+-p host_port:container_port \
+-e SERVER_PORT=application_port \
+-e GIT_SERVER_URL=gitlab_server_url \
+-e GIT_SERVER_TOKEN=gitlab_private_token \
+-e GIT_SERVER_REPO=gitlab_repository_name \
+-e GIT_SERVER_BRANCH=gitlab_branch \
+-e CONFIG_ROOT_PATH=application_config_root_folder \
+-e HOOK_SECRET_TOKEN=gitlab_header_token \
+dockerImage:tag
+
+Note :
+1. container_port should be same as application_port
+2. gitlab_server_url like "https://gitlab.com"
+3. gitlab_private_token generated in gitLab token settings.
+4. application_config_root_folder is the root folder at the application side where the files/folders of repository would be saved in.
+5. Web-hook to application EP "/reloadDynamicFlowConfigurationV2" with merge/push event can be configured at git lab.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GitLabJ-module
+# GitLabJ-module (https://hub.docker.com/r/aviorn36/gitsyncmodule)
 This modules can be integrated with your application to provide runtime-synchronization of config-files
 
 Functionality:

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.7.5</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.aviorn36</groupId>
+	<artifactId>GitSync</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>GitSync</name>
+	<description>This modules can be integrated with your application to provide runtime-synchronization of config-files</description>
+	<properties>
+		<java.version>1.8</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.gitlab4j</groupId>
+			<artifactId>gitlab4j-api</artifactId>
+			<version>5.0.1</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-devtools -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<version>2.7.5</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${project.parent.version}</version>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/java/com/aviorn36/GitSync/GitSyncSpringApplication.java
+++ b/src/main/java/com/aviorn36/GitSync/GitSyncSpringApplication.java
@@ -1,0 +1,39 @@
+package com.aviorn36.GitSync;
+
+import com.aviorn36.GitSync.GitSynchronization.services.GitSyncServices;
+import org.apache.tomcat.util.http.fileupload.FileUtils;
+import org.gitlab4j.api.GitLabApiException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+
+import java.io.File;
+import java.io.IOException;
+
+@SpringBootApplication
+public class GitSyncSpringApplication {
+
+	@Autowired
+	private GitSyncServices gitSyncServices;
+
+	@Value("${application.flow.configRootPath}")
+	private String dynamicConfigRootPath;
+
+	public static void main(String[] args) {
+		SpringApplication.run(GitSyncSpringApplication.class, args);
+	}
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void onApplicationStartUp() throws GitLabApiException, IOException {
+		String dynamicConfigurationRootPath = "./".concat(dynamicConfigRootPath);
+		FileUtils.deleteDirectory(new File(dynamicConfigurationRootPath));
+		System.out.println("Root config files/folders deleted : " + dynamicConfigurationRootPath);
+		System.out.println("Retrieving all flow configuration...");
+		gitSyncServices.loadAllConfiguration();
+		System.out.println("Flow configuration created...");
+	}
+
+}

--- a/src/main/java/com/aviorn36/GitSync/GitSynchronization/configurations/GitLabClient.java
+++ b/src/main/java/com/aviorn36/GitSync/GitSynchronization/configurations/GitLabClient.java
@@ -1,0 +1,22 @@
+package com.aviorn36.GitSync.GitSynchronization.configurations;
+
+import org.gitlab4j.api.GitLabApi;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GitLabClient {
+
+    @Value("${git.server.token}")
+    private String token;
+
+    @Value("${git.server.url}")
+    private String gitUrl;
+
+    @Bean
+    public GitLabApi getGitLabClient() {
+        return new GitLabApi(gitUrl, token);
+    }
+
+}

--- a/src/main/java/com/aviorn36/GitSync/GitSynchronization/configurations/GitWebHookManager.java
+++ b/src/main/java/com/aviorn36/GitSync/GitSynchronization/configurations/GitWebHookManager.java
@@ -1,0 +1,26 @@
+package com.aviorn36.GitSync.GitSynchronization.configurations;
+
+import org.gitlab4j.api.webhook.WebHookManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+
+@Configuration
+@DependsOn(value = "WebHookEventsImplementation")
+public class GitWebHookManager {
+    @Value("${application.flow.hookSecretToken}")
+    private String secretToken;
+    @Autowired
+    WebHookEventsImplementation webHookEventsImplementation;
+
+    @Bean
+    public WebHookManager getWebHookManagerInstance(){
+        //WebHookEventsImplementation webHookEventsImplementation = new WebHookEventsImplementation();
+        WebHookManager webHookManager = new WebHookManager(secretToken);
+        webHookManager.addListener(webHookEventsImplementation);
+        return webHookManager;
+    }
+
+}

--- a/src/main/java/com/aviorn36/GitSync/GitSynchronization/configurations/WebHookEventsImplementation.java
+++ b/src/main/java/com/aviorn36/GitSync/GitSynchronization/configurations/WebHookEventsImplementation.java
@@ -1,0 +1,26 @@
+package com.aviorn36.GitSync.GitSynchronization.configurations;
+
+import com.aviorn36.GitSync.GitSynchronization.services.GitSyncServices;
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.webhook.PushEvent;
+import org.gitlab4j.api.webhook.WebHookListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(value = "WebHookEventsImplementation")
+public class WebHookEventsImplementation implements WebHookListener {
+
+    @Autowired
+    private GitSyncServices gitSyncServices;
+
+    @Override
+    public void onPushEvent(PushEvent pushEvent) {
+        System.out.println("Push Event triggered...");
+        try {
+            gitSyncServices.loadCommittedChanges(pushEvent);
+        } catch (GitLabApiException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/com/aviorn36/GitSync/GitSynchronization/controllers/GitSyncController.java
+++ b/src/main/java/com/aviorn36/GitSync/GitSynchronization/controllers/GitSyncController.java
@@ -1,0 +1,108 @@
+package com.aviorn36.GitSync.GitSynchronization.controllers;
+
+import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.RepositoryApi;
+import org.gitlab4j.api.models.Project;
+import org.gitlab4j.api.models.RepositoryFile;
+import org.gitlab4j.api.models.TreeItem;
+import org.gitlab4j.api.webhook.Event;
+import org.gitlab4j.api.webhook.WebHookManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+public class GitSyncController {
+
+    @Value("${git.server.token}")
+    private String token;
+    @Value("${git.server.branch}")
+    private String branch;
+    @Value("${git.server.url}")
+    private String gitUrl;
+    @Value("${git.server.repo}")
+    private String repositoryName;
+    @Value("${application.flow.configRootPath}")
+    private String dynamicConfigRootPath;
+
+    @Autowired
+    private WebHookManager webHookManager;
+
+    @PostMapping("/triggerGit")
+    public String testService(){
+        System.out.println("Triggered");
+        return "triggered";
+    }
+
+    @PostMapping("/reloadDynamicFlowConfiguration")
+    public void reloadDynamicFlowConfiguration(@RequestBody Event event) throws GitLabApiException, IOException {
+        System.out.println("Reloading configuration initiated...");
+        System.out.println(event);
+        webHookManager.handleEvent(event);
+        // Create a GitLabApi instance to communicate with your GitLab server
+        GitLabApi gitLabApi = new GitLabApi(gitUrl, token);
+
+        // Get the list of projects your account has access to
+        List<Project> projects = gitLabApi.getProjectApi().getProjects(repositoryName);
+
+        Project adapterConfiguration= projects.stream().filter( project -> project.getName()
+                                                 .equalsIgnoreCase(repositoryName)).findFirst().get();
+
+        RepositoryApi repo = new RepositoryApi(gitLabApi);
+        // Branch developBranch = repo.getBranch(adapterConfiguration, "develop");
+        // List<Commit> commitsApi = new CommitsApi(gitLabApi).getCommits(adapterConfiguration);
+
+        // create root directory for flow configuration
+        File rootDirectory = new File("./".concat(dynamicConfigRootPath));
+        String rootDirectoryPath = rootDirectory.getCanonicalPath();
+        if(rootDirectory.mkdir()) {
+            System.out.println("DynamicConfiguration root directory created : " + rootDirectoryPath);
+        }else {
+            System.out.println("DynamicConfiguration root directory already existed : " + rootDirectoryPath);
+        }
+
+        List<TreeItem> fileItems = repo.getTree(adapterConfiguration, "/", branch,true).stream()
+                                    .filter(item -> {
+                                        //System.out.println(item.toString());
+                                        if(item.getType().equals(TreeItem.Type.TREE)){
+                                            //String dir = "./"+item.getName();
+                                            String dir = rootDirectoryPath.concat("/").concat(item.getPath());
+                                            File f1 = new File(dir);
+                                            if(f1.mkdir()) {
+                                                System.out.println("DynamicConfiguration sub-directory created : " + dir);
+                                            }else {
+                                                System.out.println("DynamicConfiguration sub-directory already existed : " + dir);
+                                            }
+                                            return false;
+                                        }
+                                        return item.getType().equals(TreeItem.Type.BLOB);
+                                    })
+                                    .collect(Collectors.toList());
+
+        RepositoryFile repoFile = null;
+        for(TreeItem file : fileItems){
+            repoFile = gitLabApi.getRepositoryFileApi().getFile(adapterConfiguration,file.getPath(),branch);
+            //String path = new File(".").getCanonicalPath() + "/".concat(repoFile.getFilePath());
+            String path = rootDirectoryPath.concat("/").concat(repoFile.getFilePath());
+            try {
+                File newFile = new File(path);
+                newFile.createNewFile();
+                Files.write(Paths.get(path), repoFile.getDecodedContentAsBytes());
+                System.out.println("DynamicConfiguration file created/updated : " + path);
+            }catch (Exception e){
+                System.out.println("DynamicConfiguration file creation/updation failed : " + path);
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/com/aviorn36/GitSync/GitSynchronization/controllers/GitSyncControllerV2.java
+++ b/src/main/java/com/aviorn36/GitSync/GitSynchronization/controllers/GitSyncControllerV2.java
@@ -1,0 +1,36 @@
+package com.aviorn36.GitSync.GitSynchronization.controllers;
+
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.webhook.Event;
+import org.gitlab4j.api.webhook.WebHookManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+public class GitSyncControllerV2 {
+
+    @Value("${git.server.token}")
+    private String token;
+    @Value("${git.server.branch}")
+    private String branch;
+    @Value("${git.server.url}")
+    private String gitUrl;
+    @Value("${git.server.repo}")
+    private String repositoryName;
+    @Value("${application.flow.configRootPath}")
+    private String dynamicConfigRootPath;
+
+    @Autowired
+    private WebHookManager webHookManager;
+
+    @PostMapping("/reloadDynamicFlowConfigurationV2")
+    public void reloadDynamicFlowConfiguration(@RequestBody Event event) throws GitLabApiException, IOException {
+        System.out.println("Reloading configuration initiated...");
+        webHookManager.handleEvent(event);
+    }
+}

--- a/src/main/java/com/aviorn36/GitSync/GitSynchronization/services/GitSyncServices.java
+++ b/src/main/java/com/aviorn36/GitSync/GitSynchronization/services/GitSyncServices.java
@@ -1,0 +1,102 @@
+package com.aviorn36.GitSync.GitSynchronization.services;
+
+import com.aviorn36.GitSync.GitSynchronization.utilities.GitSyncUtilities;
+import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.RepositoryApi;
+import org.gitlab4j.api.models.Project;
+import org.gitlab4j.api.models.TreeItem;
+import org.gitlab4j.api.webhook.EventCommit;
+import org.gitlab4j.api.webhook.PushEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+public class GitSyncServices {
+
+    @Autowired
+    private GitLabApi gitLabApi;
+
+    @Value("${git.server.repo}")
+    private String repositoryName;
+
+    @Value("${application.flow.configRootPath}")
+    private String dynamicConfigRootPath;
+
+    @Value("${git.server.branch}")
+    private String branch;
+
+    /*
+    To be used when application restarts. This reloads files and folders present in gitLab:repositoryName inside application:dynamicConfigRootPath
+    Note: Recursively delete dynamicConfigRootPath before calling this or take backup automatically
+    */
+    public void loadAllConfiguration() throws GitLabApiException {
+
+        // get project from gitLab
+        Project dynamicConfigurationProject = GitSyncUtilities.getGitProject(gitLabApi, repositoryName);
+
+        // create directory for flow configuration in application root path
+        String dynamicConfigurationRootPath = "./".concat(dynamicConfigRootPath);
+        GitSyncUtilities.createDirectory(dynamicConfigurationRootPath);
+
+        // get tree structure of files present in repo and create directories structure inside dynamicConfigurationRootPath
+        List<TreeItem> filesTreeItems = GitSyncUtilities.getAllFilesAndCreateDirectory(dynamicConfigurationProject, new RepositoryApi(gitLabApi), branch, dynamicConfigurationRootPath);
+
+        // create files inside dynamicConfigurationRootPath directories in application
+        GitSyncUtilities.createFilesFromTreeItems(gitLabApi, dynamicConfigurationProject, branch, filesTreeItems, dynamicConfigurationRootPath);
+    }
+
+    public void loadCommittedChanges(PushEvent pushEvent) throws GitLabApiException {
+        //System.out.println(pushEvent);
+        Project dynamicConfigurationProject = GitSyncUtilities.getGitProject(gitLabApi, repositoryName);
+        String dynamicConfigurationRootPath = "./".concat(dynamicConfigRootPath);
+        pushEvent.getCommits().stream().forEach(
+                eventCommit -> {
+                    System.out.println("Processing commit :" + eventCommit.getId());
+                    processRemovedItems(dynamicConfigurationRootPath, eventCommit);
+                    processAddedItems(dynamicConfigurationProject, dynamicConfigurationRootPath, eventCommit);
+                    processModifiedItems(dynamicConfigurationProject, dynamicConfigurationRootPath, eventCommit);
+                }
+        );
+
+    }
+
+    private void processModifiedItems(Project dynamicConfigurationProject, String dynamicConfigurationRootPath, EventCommit eventCommit) {
+        eventCommit.getModified().stream().forEach(modifiedItem -> {
+            try {
+                GitSyncUtilities.processModifiedItem(gitLabApi, dynamicConfigurationProject, branch, dynamicConfigurationRootPath, modifiedItem);
+            } catch (GitLabApiException e) {
+                //throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void processAddedItems(Project dynamicConfigurationProject, String dynamicConfigurationRootPath, EventCommit eventCommit) {
+        eventCommit.getAdded().stream().forEach(addedItem -> {
+            try {
+                String addedItemPath = addedItem.substring(0,addedItem.lastIndexOf("/"));
+                //String addedItemName = addedItem.substring(addedItem.lastIndexOf("/")+1);
+                GitSyncUtilities.processAddedItem(gitLabApi, dynamicConfigurationProject, branch, dynamicConfigurationRootPath, addedItemPath, addedItem);
+            } catch (GitLabApiException e) {
+                //throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void processRemovedItems(String dynamicConfigurationRootPath, EventCommit eventCommit) {
+        eventCommit.getRemoved().stream().forEach(removedItem -> {
+            try {
+                GitSyncUtilities.processRemovedItem(dynamicConfigurationRootPath.concat("/").concat(removedItem));
+                //String removedItemPath = removedItem.substring(0,removedItem.lastIndexOf("/"));
+                //System.out.println("removedItemPath :" +removedItemPath);
+
+            } catch (IOException e) {
+                //throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/src/main/java/com/aviorn36/GitSync/GitSynchronization/utilities/GitSyncUtilities.java
+++ b/src/main/java/com/aviorn36/GitSync/GitSynchronization/utilities/GitSyncUtilities.java
@@ -1,0 +1,91 @@
+package com.aviorn36.GitSync.GitSynchronization.utilities;
+
+import org.gitlab4j.api.GitLabApi;
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.RepositoryApi;
+import org.gitlab4j.api.models.Project;
+import org.gitlab4j.api.models.RepositoryFile;
+import org.gitlab4j.api.models.TreeItem;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GitSyncUtilities {
+
+    public static Project getGitProject(GitLabApi gitLabApi, String repositoryName) throws GitLabApiException {
+        List<Project> projects = gitLabApi.getProjectApi().getProjects(repositoryName);
+        return projects.stream().filter( project -> project.getName().equalsIgnoreCase(repositoryName)).findFirst().get();
+    }
+
+    public static void createDirectory(String path) {
+        File directory = new File(path);
+        if(directory.mkdir()) {
+            System.out.println("DynamicConfiguration directory created : " + path);
+        }else {
+            System.out.println("DynamicConfiguration directory already existed : " + path);
+        }
+    }
+
+    private static void createFile(byte[] bytesInput, String path) throws IOException {
+        File file = new File(path);
+        file.createNewFile();
+        Files.write(Paths.get(path), bytesInput);
+    }
+
+    private static void removeFile(String path) throws IOException {
+        File file = new File(path);
+        file.delete();
+    }
+
+    public static List<TreeItem> getAllFilesAndCreateDirectory(Project project, RepositoryApi repositoryClient, String branch, String rootDirectoryPath) throws GitLabApiException {
+        return repositoryClient.getTree(project, "/", branch,true).stream()
+                .filter(item -> {
+                    if(item.getType().equals(TreeItem.Type.TREE)){
+                        //System.out.println(rootDirectoryPath.concat("/").concat(item.getPath()));
+                        createDirectory(rootDirectoryPath.concat("/").concat(item.getPath()));
+                        return false;
+                    }
+                    return item.getType().equals(TreeItem.Type.BLOB);
+                }).collect(Collectors.toList());
+    }
+
+    public static void createFilesFromTreeItems(GitLabApi gitLabApi, Project project, String branch, List<TreeItem> treeItems, String rootDirectoryPath) throws GitLabApiException {
+        for(TreeItem file : treeItems){
+            getAndCreateRemoteFile(gitLabApi, project, branch, rootDirectoryPath, file.getPath());
+        }
+    }
+
+    private static void getAndCreateRemoteFile(GitLabApi gitLabApi, Project project, String branch, String rootDirectoryPath, String file) throws GitLabApiException {
+        RepositoryFile repoFile = null;
+        repoFile = gitLabApi.getRepositoryFileApi().getFile(project, file, branch);
+        String path = rootDirectoryPath.concat("/").concat(repoFile.getFilePath());
+        try {
+            createFile(repoFile.getDecodedContentAsBytes(), path);
+            System.out.println("DynamicConfiguration file created/updated : " + path);
+        }catch (Exception e){
+            System.out.println("DynamicConfiguration file creation/updation failed : " + path);
+            e.printStackTrace();
+        }
+    }
+
+    public static void processRemovedItem(String item) throws IOException {
+        System.out.println("removing :" + item);
+        removeFile(item);
+    }
+
+    public static void processAddedItem(GitLabApi gitLabApi, Project project, String branch,String dynamicConfigurationRootPath, String itemPath, String item) throws GitLabApiException {
+        System.out.println("adding :" + item);
+        createDirectory(dynamicConfigurationRootPath.concat("/").concat(itemPath));
+        getAndCreateRemoteFile(gitLabApi, project, branch,dynamicConfigurationRootPath, item);
+    }
+
+    public static void processModifiedItem(GitLabApi gitLabApi, Project project, String branch,String dynamicConfigurationRootPath, String item) throws GitLabApiException {
+        System.out.println("modifying :" + item);
+        getAndCreateRemoteFile(gitLabApi, project, branch,dynamicConfigurationRootPath, item);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+git:
+  server:
+    url: ${GIT_SERVER_URL}
+    token: ${GIT_SERVER_TOKEN}
+    repo: ${GIT_SERVER_REPO}
+    branch: ${GIT_SERVER_BRANCH}
+
+application:
+  flow:
+    configRootPath: ${CONFIG_ROOT_PATH}
+    hookSecretToken: ${HOOK_SECRET_TOKEN}
+
+server:
+  port: ${SERVER_PORT}


### PR DESCRIPTION
## Merge develop → main

Brings the full project source code from the `develop` branch into `main`, which currently only contains a `.gitignore` and a minimal README.

### What's being added
- **`pom.xml`** — Maven build configuration (Spring Boot 2.7.5, gitlab4j-api 5.0.1)
- **`Dockerfile`** — Docker image definition for containerized deployment
- **`src/`** — Java source code for the GitSync module
- **`README.md`** — Updated documentation with usage instructions, environment variables, and Docker commands

### Functionality
1. **Initialization** — Connects to GitLab and downloads/saves files & folders to the application server based on environment configuration
2. **Runtime Reload** — Exposes `/reloadDynamicFlowConfigurationV2` endpoint for dynamic config reload triggered via GitLab webhooks (push/merge events)

### Known Issue
- Webhook-based reload only updates the replica that receives the call in multi-replica deployments, causing config drift across other replicas. Tracked in #1.

### Notes
- The `develop` branch has been the active working branch since project inception — this PR makes `main` reflect the actual state of the project.